### PR TITLE
Add Interworx implementation

### DIFF
--- a/src/InterWorx/Api.php
+++ b/src/InterWorx/Api.php
@@ -37,14 +37,14 @@ class Api
         return $this->client = $client;
     }
 
-    public function makeRequest(string $api_controller, string $action, array $input): ?array
+    public function makeRequest(string $controller, string $action, array $input): ?array
     {
         $key = array(
             'email' => $this->configuration->username,
             'password' => $this->configuration->password
         );
 
-        $response = $this->client()->route($key, $api_controller, $action, $input);
+        $response = $this->client()->route($key, $controller, $action, $input);
 
         if (empty($response)) {
             throw new RuntimeException('Empty api response');
@@ -170,21 +170,21 @@ class Api
 
     private function getSiteWorxAccount(string $domain)
     {
-        $api_controller = '/nodeworx/siteworx';
+        $apiController = '/nodeworx/siteworx';
         $action = 'querySiteworxAccountDetails';
         $input = array(
             'domain' => $domain
         );
 
-        return $this->makeRequest($api_controller, $action, $input)['payload'];
+        return $this->makeRequest($apiController, $action, $input)['payload'];
     }
 
     private function getResellerAccount(string $username): ?array
     {
-        $api_controller = '/nodeworx/reseller';
+        $apiController = '/nodeworx/reseller';
         $action = 'listResellers';
 
-        $response = $this->makeRequest($api_controller, $action, [])['payload'];
+        $response = $this->makeRequest($apiController, $action, [])['payload'];
 
         $result = Null;
 
@@ -219,13 +219,13 @@ class Api
 
     public function getDomainName(string $username): string
     {
-        $api_controller = '/nodeworx/siteworx';
+        $controller = '/nodeworx/siteworx';
         $action = 'querySiteworxAccounts';
         $input = array(
             'unixuser' => $username
         );
 
-        $response = $this->makeRequest($api_controller, $action, $input)['payload'];
+        $response = $this->makeRequest($controller, $action, $input)['payload'];
 
         return $response[0]['domain'];
     }
@@ -277,7 +277,7 @@ class Api
 
     public function suspendAccount(string $domain, ?string $reason): void
     {
-        $api_controller = '/nodeworx/siteworx';
+        $controller = '/nodeworx/siteworx';
         $action = 'suspend';
         $input = array(
             'domain' => $domain
@@ -287,34 +287,34 @@ class Api
             $input['message'] = $reason;
         }
 
-        $this->makeRequest($api_controller, $action, $input);
+        $this->makeRequest($controller, $action, $input);
     }
 
     public function unsuspendAccount(string $username): void
     {
-        $api_controller = '/nodeworx/siteworx';
+        $controller = '/nodeworx/siteworx';
         $action = 'unsuspendByUser';
         $input = array(
             'user' => $username
         );
 
-        $this->makeRequest($api_controller, $action, $input);
+        $this->makeRequest($controller, $action, $input);
     }
 
     public function deleteAccount(string $domain): void
     {
-        $api_controller = '/nodeworx/siteworx';
+        $controller = '/nodeworx/siteworx';
         $action = 'delete';
         $input = array(
             'domain' => $domain
         );
 
-        $this->makeRequest($api_controller, $action, $input);
+        $this->makeRequest($controller, $action, $input);
     }
 
     public function updatePassword(string $domain, string $password): void
     {
-        $api_controller = '/nodeworx/siteworx';
+        $controller = '/nodeworx/siteworx';
         $action = 'edit';
         $input = array(
             'domain' => $domain,
@@ -322,31 +322,31 @@ class Api
             'confirm_password' => $password,
         );
 
-        $this->makeRequest($api_controller, $action, $input);
+        $this->makeRequest($controller, $action, $input);
     }
 
     public function updatePackage(string $domain, string $package)
     {
-        $api_controller = '/nodeworx/siteworx';
+        $controller = '/nodeworx/siteworx';
         $action = 'edit';
         $input = array(
             'domain' => $domain,
             'packagetemplate' => $package,
         );
 
-        $this->makeRequest($api_controller, $action, $input);
+        $this->makeRequest($controller, $action, $input);
     }
 
     public function deleteReseller(string $username): void
     {
         $reseller = $this->getResellerAccount($username);
 
-        $api_controller = '/nodeworx/reseller';
+        $controller = '/nodeworx/reseller';
         $action = 'delete';
         $input = array(
             'reseller_id' => $reseller['reseller_id'],
         );
 
-        $this->makeRequest($api_controller, $action, $input);
+        $this->makeRequest($controller, $action, $input);
     }
 }

--- a/src/InterWorx/Api.php
+++ b/src/InterWorx/Api.php
@@ -1,0 +1,352 @@
+<?php
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\InterWorx;
+
+use ErrorException;
+use Illuminate\Support\Arr;
+use Psr\Log\LoggerInterface;
+use SoapClient;
+use Upmind\ProvisionBase\Helper;
+use Throwable;
+use RuntimeException;
+use Illuminate\Support\Str;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\UnitsConsumed;
+use Upmind\ProvisionProviders\SharedHosting\Data\UsageData;
+use Upmind\ProvisionProviders\SharedHosting\InterWorx\Data\Configuration;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+
+class Api
+{
+    private Configuration $configuration;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    protected function client(): SoapClient
+    {
+        if (isset($this->client)) {
+            return $this->client;
+        }
+
+        $client = new SoapClient("https://{$this->configuration->hostname}:{$this->configuration->port}/soap?wsdl");
+
+        return $this->client = $client;
+    }
+
+    public function makeRequest(string $api_controller, string $action, array $input): ?array
+    {
+        $key = array(
+            'email' => $this->configuration->username,
+            'password' => $this->configuration->password
+        );
+
+        $response = $this->client()->route($key, $api_controller, $action, $input);
+
+        if (empty($response)) {
+            throw new RuntimeException('Empty api response');
+        }
+
+        return $this->parseResponseData($response);
+    }
+
+    private function parseResponseData(array $response): ?array
+    {
+        if (!array_key_exists('status', $response) || !array_key_exists('payload', $response)) {
+            throw ProvisionFunctionError::create('Unknown Error')
+                ->withData([
+                    'response' => $response,
+                ]);
+        }
+
+        if ($error = $this->getResponseErrorMessage($response)) {
+            throw ProvisionFunctionError::create($error)
+                ->withData([
+                    'response' => $response,
+                ]);
+        }
+
+        return $response;
+    }
+
+    private function getResponseErrorMessage(array $response): ?string
+    {
+        $statusCode = $response['status'] ?? 'unknown';
+        if ($statusCode == 0) {
+            return null;
+        }
+
+        $errorMessages = [];
+        if ($statusCode == 11) {
+            if (Str::contains($response['payload'], 'Unixname is already in use')) {
+                $errorMessages[] = 'Username is already in use';
+            }
+
+            if (Str::contains($response['payload'], 'Domain name already exists')) {
+                $errorMessages[] = 'Domain name already exists';
+            }
+
+            if (preg_match('/unixuser: .* This is not a valid option/', $response['payload'])) {
+                $errorMessages[] = 'Account does not exist';
+            }
+
+            if (preg_match('/domain: .* This is not a valid option/', $response['payload'])) {
+                $errorMessages[] = 'Account does not exist';
+            }
+
+            if (preg_match('/packagetemplate: .* This is not a valid option/', $response['payload'])) {
+                $errorMessages[] = 'Invalid package name';
+            }
+
+            if (count($errorMessages) == 0) {
+                $lines = explode("\n", $response['payload']);
+                return $lines[1] ?? 'Unknown Error';
+            }
+        }
+
+        return implode('. ', $errorMessages);
+    }
+
+    public function createAccount(CreateParams $params, string $username, bool $asReseller): void
+    {
+        $password = $params->password ?: Helper::generatePassword();
+
+        $input = array(
+            'email' => $params->email,
+            'password' => $password,
+            'confirm_password' => $password,
+            'packagetemplate' => $params->package_name,
+        );
+
+        if ($asReseller) {
+            $input['ipv4'] = $params->custom_ip;
+            $input['nickname'] = $username;
+            $input['status'] = 'active';
+
+            $this->createResellerAccount($input);
+        } else {
+            $input['master_domain'] = $params->domain;
+            $input['master_domain_ipv4'] = $params->custom_ip;
+            $input['uniqname'] = $username;
+
+            $this->createSiteworxAccount($input);
+        }
+    }
+
+    private function createResellerAccount(array $input): void
+    {
+        $this->makeRequest('/nodeworx/reseller', 'add', $input);
+    }
+
+    private function createSiteworxAccount(array $input): void
+    {
+        $this->makeRequest('/nodeworx/siteworx', 'add', $input);
+    }
+
+    /**
+     * @param string $domain
+     * @return array
+     */
+    public function getAccountData(string $domain): array
+    {
+        $account = $this->getSiteWorxAccount($domain);
+        $suspended = $account['status'] === 'inactive';
+        $suspendReason = $suspended ? (string)$account['inactive_msg'] : null;
+
+        return array(
+            'username' => $account['unixuser'],
+            'domain' => $account['domain'],
+            'reseller' => false,
+            'server_hostname' => $this->configuration->hostname,
+            'package_name' => $account['package_name'],
+            'suspended' => $suspended,
+            'suspend_reason' => $suspendReason !== '' ? $suspendReason : null,
+            'ip' => $account['ip'],
+        );
+    }
+
+    private function getSiteWorxAccount(string $domain)
+    {
+        $api_controller = '/nodeworx/siteworx';
+        $action = 'querySiteworxAccountDetails';
+        $input = array(
+            'domain' => $domain
+        );
+
+        return $this->makeRequest($api_controller, $action, $input)['payload'];
+    }
+
+    private function getResellerAccount(string $username): ?array
+    {
+        $api_controller = '/nodeworx/reseller';
+        $action = 'listResellers';
+
+        $response = $this->makeRequest($api_controller, $action, [])['payload'];
+
+        $result = Null;
+
+        foreach ($response as $reseller) {
+            $reseller = (array)$reseller;
+
+            if ($reseller['nickname'] === $username) {
+                $result = $reseller;
+                break;
+            }
+        }
+
+        if (!$result) {
+            throw ProvisionFunctionError::create('Account does not exist');
+        }
+
+        return $result;
+    }
+
+    public function getResellerData(string $username): ?array
+    {
+        $reseller = $this->getResellerAccount($username);
+
+        return array(
+            'username' => $reseller['nickname'],
+            'server_hostname' => $this->configuration->hostname,
+            'package_name' => '-',
+            'reseller' => true,
+            'suspended' => false,
+        );
+    }
+
+    public function getDomainName(string $username): string
+    {
+        $api_controller = '/nodeworx/siteworx';
+        $action = 'querySiteworxAccounts';
+        $input = array(
+            'unixuser' => $username
+        );
+
+        $response = $this->makeRequest($api_controller, $action, $input)['payload'];
+
+        return $response[0]['domain'];
+    }
+
+    public function getAccountUsage(string $domain): UsageData
+    {
+        $account = $this->getSiteWorxAccount($domain);
+
+        $storage = $account['storage'] ?? null;
+
+        if (!is_null($storage)) {
+            $storage = (int)$storage;
+        }
+
+        $disk = UnitsConsumed::create()
+            ->setUsed((int)$account['storage_used'])
+            ->setLimit($storage != 0 ? $storage : null);
+
+        $bandwidth = UnitsConsumed::create()
+            ->setUsed((int)$account['bandwidth_used'] * 1024)
+            ->setLimit((int)$account['bandwidth'] * 1024);
+
+        return UsageData::create()
+            ->setDiskMb($disk)
+            ->setBandwidthMb($bandwidth);
+    }
+
+    public function getResellerAccountUsage(string $username): UsageData
+    {
+        $account = $this->getResellerAccount($username);
+
+        $maxStorage = $account['max_storage'] ?? null;
+        if (!is_null($maxStorage)) {
+            $maxStorage = (int)$maxStorage;
+        }
+
+        $disk = UnitsConsumed::create()
+            ->setUsed((int)$account['storage'])
+            ->setLimit($maxStorage != 0 ? $maxStorage : null);
+
+        $bandwidth = UnitsConsumed::create()
+            ->setUsed((int)$account['bandwidth'] * 1024)
+            ->setLimit((int)$account['max_bandwidth'] * 1024);
+
+        return UsageData::create()
+            ->setDiskMb($disk)
+            ->setBandwidthMb($bandwidth);
+    }
+
+    public function suspendAccount(string $domain, ?string $reason): void
+    {
+        $api_controller = '/nodeworx/siteworx';
+        $action = 'suspend';
+        $input = array(
+            'domain' => $domain
+        );
+
+        if ($reason) {
+            $input['message'] = $reason;
+        }
+
+        $this->makeRequest($api_controller, $action, $input);
+    }
+
+    public function unsuspendAccount(string $username): void
+    {
+        $api_controller = '/nodeworx/siteworx';
+        $action = 'unsuspendByUser';
+        $input = array(
+            'user' => $username
+        );
+
+        $this->makeRequest($api_controller, $action, $input);
+    }
+
+    public function deleteAccount(string $domain): void
+    {
+        $api_controller = '/nodeworx/siteworx';
+        $action = 'delete';
+        $input = array(
+            'domain' => $domain
+        );
+
+        $this->makeRequest($api_controller, $action, $input);
+    }
+
+    public function updatePassword(string $domain, string $password): void
+    {
+        $api_controller = '/nodeworx/siteworx';
+        $action = 'edit';
+        $input = array(
+            'domain' => $domain,
+            'password' => $password,
+            'confirm_password' => $password,
+        );
+
+        $this->makeRequest($api_controller, $action, $input);
+    }
+
+    public function updatePackage(string $domain, string $package)
+    {
+        $api_controller = '/nodeworx/siteworx';
+        $action = 'edit';
+        $input = array(
+            'domain' => $domain,
+            'packagetemplate' => $package,
+        );
+
+        $this->makeRequest($api_controller, $action, $input);
+    }
+
+    public function deleteReseller(string $username): void
+    {
+        $reseller = $this->getResellerAccount($username);
+
+        $api_controller = '/nodeworx/reseller';
+        $action = 'delete';
+        $input = array(
+            'reseller_id' => $reseller['reseller_id'],
+        );
+
+        $this->makeRequest($api_controller, $action, $input);
+    }
+}

--- a/src/InterWorx/Data/Configuration.php
+++ b/src/InterWorx/Data/Configuration.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\InterWorx\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * InterWorx API credentials.
+ * @property-read string $hostname InterWorx server hostname
+ * @property-read string $port InterWorx server port
+ * @property-read string $username InterWorx username
+ * @property-read string $password InterWorx password
+ * @property-read bool|null $debug Whether or not to enable debug logging
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'hostname' => ['required', 'domain_name'],
+            'port' => ['required', 'integer'],
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+            'debug' => ['boolean'],
+        ]);
+    }
+}

--- a/src/InterWorx/Provider.php
+++ b/src/InterWorx/Provider.php
@@ -1,0 +1,328 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\InterWorx;
+
+use GuzzleHttp\Client;
+use Throwable;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionProviders\SharedHosting\Category;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountInfo;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsage;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsername;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePasswordParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\EmptyResult;
+use Upmind\ProvisionProviders\SharedHosting\Data\GetLoginUrlParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\GrantResellerParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\LoginUrl;
+use Upmind\ProvisionProviders\SharedHosting\Data\ResellerPrivileges;
+use Upmind\ProvisionProviders\SharedHosting\Data\SuspendParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\UsageData;
+use Upmind\ProvisionProviders\SharedHosting\InterWorx\Data\Configuration;
+
+/**
+ * Example hosting provider template.
+ */
+class Provider extends Category implements ProviderInterface
+{
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
+
+    /**
+     * @var Api
+     */
+    protected $api;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('InterWorx')
+            ->setDescription('Create and manage InterWorx accounts and resellers using the InterWorx API')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/interworx-logo@2x.png');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(CreateParams $params): AccountInfo
+    {
+        $asReseller = boolval($params->as_reseller ?? false);
+
+        if (!$asReseller) {
+            if (!$params->domain) {
+                throw $this->errorResult('Domain name is required');
+            }
+        }
+
+        if (!$params->custom_ip) {
+            throw $this->errorResult('Domain IP is required');
+        }
+
+        $username = $params->username ?? $this->generateUsername($params->domain);
+
+        try {
+            $this->api()->createAccount(
+                $params,
+                $username,
+                $asReseller,
+            );
+
+            if ($asReseller) {
+                return $this->_getInfo($username, true, 'Reseller account created');
+            } else {
+                return $this->_getInfo($params->domain, false, 'Account created');
+            }
+
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    protected function generateUsername(string $base): string
+    {
+        return substr(
+            preg_replace('/^[^a-z]+/', '', preg_replace('/[^a-z0-9]/', '', strtolower($base))),
+            0,
+            $this->getMaxUsernameLength()
+        );
+    }
+
+    protected function getMaxUsernameLength(): int
+    {
+        return 16;
+    }
+
+    protected function _getInfo(string $domain, bool $isReseller, string $message): AccountInfo
+    {
+        if ($isReseller) {
+            $info = $this->api()->getResellerData($domain);
+        } else {
+            $info = $this->api()->getAccountData($domain);
+        }
+
+        return AccountInfo::create($info)->setMessage($message);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getInfo(AccountUsername $params): AccountInfo
+    {
+        try {
+            if (isset($params->is_reseller) && boolval($params->is_reseller)) {
+                return $this->_getInfo($params->username,
+                    true,
+                    'Account info retrieved',
+                );
+            }
+
+            $domain = $this->api()->getDomainName($params->username);
+
+            return $this->_getInfo($domain,
+                false,
+                'Account info retrieved',
+            );
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function getUsage(AccountUsername $params): AccountUsage
+    {
+        try {
+            if (isset($params->is_reseller) && boolval($params->is_reseller)) {
+                $usage = $this->api()->getResellerAccountUsage(
+                    $params->username,
+                );
+
+                return AccountUsage::create()
+                    ->setUsageData($usage);
+            }
+
+            if (!$params->domain) {
+                $domain = $this->api()->getDomainName($params->username);
+            } else {
+                $domain = $params->domain;
+            }
+
+            $usage = $this->api()->getAccountUsage($domain,);
+
+            return AccountUsage::create()
+                ->setUsageData($usage);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLoginUrl(GetLoginUrlParams $params): LoginUrl
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function changePassword(ChangePasswordParams $params): EmptyResult
+    {
+        try {
+            $domain = $this->api()->getDomainName($params->username);
+
+            $this->api()->updatePassword($domain, $params->password);
+
+            return $this->emptyResult('Password changed');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function changePackage(ChangePackageParams $params): AccountInfo
+    {
+        try {
+            $domain = $this->api()->getDomainName($params->username);
+
+            $this->api()->updatePackage($domain, $params->package_name);
+
+            return $this->_getInfo(
+                $domain,
+                false,
+                'Package changed');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function suspend(SuspendParams $params): AccountInfo
+    {
+        try {
+            if (!$params->domain) {
+                $domain = $this->api()->getDomainName($params->username);
+            } else {
+                $domain = $params->domain;
+            }
+
+            $this->api()->suspendAccount($domain, $params->reason ?? null);
+
+            return $this->_getInfo($domain, false, 'Account suspended');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unSuspend(AccountUsername $params): AccountInfo
+    {
+        try {
+            if (isset($params->is_reseller) && boolval($params->is_reseller)) {
+                throw $this->errorResult('Unsuspend reseller account not supported');
+            }
+
+            $this->api()->unsuspendAccount($params->username);
+
+            if (!$params->domain) {
+                $domain = $this->api()->getDomainName($params->username);
+            } else {
+                $domain = $params->domain;
+            }
+
+            return $this->_getInfo($domain, false, 'Account unsuspended');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function terminate(AccountUsername $params): EmptyResult
+    {
+        try {
+            if (isset($params->is_reseller) && boolval($params->is_reseller)) {
+                $this->api()->deleteReseller($params->username,);
+
+                return $this->emptyResult('Account deleted');
+            }
+
+            if (!$params->domain) {
+                $domain = $this->api()->getDomainName($params->username);
+            } else {
+                $domain = $params->domain;
+            }
+
+            $this->api()->deleteAccount($domain);
+
+            return $this->emptyResult('Account deleted');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function grantReseller(GrantResellerParams $params): ResellerPrivileges
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function revokeReseller(AccountUsername $params): ResellerPrivileges
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws Throwable
+     */
+    protected function handleException(Throwable $e, array $data = [], array $debug = [], ?string $message = null): void
+    {
+        if ($e instanceof ProvisionFunctionError) {
+            throw $e->withData(
+                array_merge($e->getData(), $data)
+            )->withDebug(
+                array_merge($e->getDebug(), $debug)
+            );
+        }
+
+        // let the provision system handle this one
+        throw $e;
+    }
+
+
+    protected function api(): Api
+    {
+        if (isset($this->api)) {
+            return $this->api;
+        }
+
+        return $this->api ??= new Api($this->configuration);
+    }
+}

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -12,6 +12,7 @@ use Upmind\ProvisionProviders\SharedHosting\WHMv1\Provider as WHMv1;
 use Upmind\ProvisionProviders\SharedHosting\PleskOnyxRPC\Provider as PleskOnyxRPC;
 use Upmind\ProvisionProviders\SharedHosting\TwentyI\Provider as TwentyI;
 use Upmind\ProvisionProviders\SharedHosting\Enhance\Provider as Enhance;
+use Upmind\ProvisionProviders\SharedHosting\InterWorx\Provider as InterWorx;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -26,5 +27,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('shared-hosting', 'plesk-onyx', PleskOnyxRPC::class);
         $this->bindProvider('shared-hosting', '20i', TwentyI::class);
         $this->bindProvider('shared-hosting', 'enhance', Enhance::class);
+        $this->bindProvider('shared-hosting', 'inter-worx', InterWorx::class);
     }
 }


### PR DESCRIPTION
The following operations are implemented for Interworx:

- create()
- getInfo() 
- getUsage()
- getLoginUrl()
- changePassword()
- changePackage()
- suspend()
- unSuspend()
- terminate()
- grantReseller()
- revokeReseller()

The following operations aren't supported by Interworx:

- getLoginUrl() 
- grantReseller()
- revokeReseller()