### PR TITLE
Add DirectAdmin implementation

### DIFF
--- a/src/DirectAdmin/Api.php
+++ b/src/DirectAdmin/Api.php
@@ -1,0 +1,250 @@
+<?php
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\DirectAdmin;
+
+use ErrorException;
+use Illuminate\Support\Arr;
+use Psr\Log\LoggerInterface;
+use GuzzleHttp\Client;
+use Upmind\ProvisionBase\Helper;
+use Throwable;
+use RuntimeException;
+use Illuminate\Support\Str;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\UnitsConsumed;
+use Upmind\ProvisionProviders\SharedHosting\Data\UsageData;
+use Upmind\ProvisionProviders\SharedHosting\DirectAdmin\Data\Configuration;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+
+class Api
+{
+    protected Client $client;
+    private Configuration $configuration;
+
+    public function __construct(Client $client, Configuration $configuration)
+    {
+        $this->client = $client;
+        $this->configuration = $configuration;
+    }
+
+    public function makeRequest(
+        string  $command,
+        ?array  $params = null,
+        ?array  $body = null,
+        ?string $method = 'GET',
+        ?array  $credentials = null
+    ): ?array
+    {
+        $requestParams = [];
+
+        if ($params) {
+            $requestParams['query'] = $params;
+        }
+
+        if ($body) {
+            $requestParams['form_params'] = $body;
+        }
+
+        if ($credentials) {
+            $requestParams['auth'] = $credentials;
+        }
+
+        $requestParams['query']['json'] = 'yes';
+
+        $response = $this->client->request($method, $command, $requestParams);
+        $result = $response->getBody()->getContents();
+
+        $response->getBody()->close();
+
+        if ($result === "") {
+            return null;
+        }
+
+        return $this->parseResponseData($result);
+    }
+
+    private function parseResponseData(string $response): array
+    {
+        $parsedResult = json_decode($response, true);
+
+        if (!$parsedResult) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $response,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+    public function createAccount(CreateParams $params, string $username, bool $asReseller): void
+    {
+        $password = $params->password ?: Helper::generatePassword();
+
+        if ($asReseller) {
+            $command = '/CMD_API_ACCOUNT_RESELLER';
+        } else {
+            $command = '/CMD_API_ACCOUNT_USER';
+        }
+
+        $query = array(
+            'action' => 'create',
+            'add' => 'Submit',
+            'username' => $username,
+            'email' => $params->email,
+            'passwd' => $password,
+            'passwd2' => $password,
+            'domain' => $params->domain,
+            'package' => $params->package_name,
+            'ip' => $params->custom_ip,
+        );
+
+        $this->makeRequest($command, $query);
+    }
+
+    public function getAccountData(string $username): array
+    {
+        $account = $this->getUserConfig($username);
+
+        return array(
+            'username' => $account['username'],
+            'domain' => $account['domain'] ?? null,
+            'reseller' => $account['usertype'] === 'reseller',
+            'server_hostname' => $this->configuration->hostname,
+            'package_name' => $account['package'],
+            'suspended' => $account['suspended'] === 'yes',
+            'suspend_reason' => $account['suspended_reason'] ?? null,
+            'ip' => $account['ip'] ?? null,
+            'nameservers' => [$account['ns1'] ?? null, $account['ns2'] ?? null],
+        );
+    }
+
+    public function getUserConfig(string $username): array
+    {
+        $command = '/CMD_API_SHOW_USER_CONFIG';
+        $query = array(
+            'user' => $username,
+        );
+
+        return $this->makeRequest($command, $query);
+    }
+
+    public function suspendAccount(string $username): void
+    {
+        $command = '/CMD_API_SELECT_USERS';
+        $query = array(
+            'select0' => $username,
+            'suspend' => 'Suspend',
+        );
+
+        $this->makeRequest($command, $query, null, 'POST');
+    }
+
+    public function unsuspendAccount(string $username): void
+    {
+        $command = '/CMD_API_SELECT_USERS';
+        $query = array(
+            'select0' => $username,
+            'suspend' => 'Unsuspend',
+        );
+
+        $this->makeRequest($command, $query, null, 'POST');
+    }
+
+    public function deleteAccount(string $username): void
+    {
+        $command = '/CMD_API_SELECT_USERS';
+        $query = array(
+            'confirmed' => 'Confirm',
+            'select0' => $username,
+            'delete' => 'yes',
+        );
+
+        $this->makeRequest($command, $query, null, 'POST');
+    }
+
+    public function updatePassword(string $username, string $password): void
+    {
+        $command = '/CMD_API_USER_PASSWD';
+        $body = array(
+            'username' => $username,
+            'passwd' => $password,
+            'passwd2' => $password,
+        );
+
+        $this->makeRequest($command, null, $body, 'POST');
+    }
+
+    public function updatePackage(string $username, string $package_name)
+    {
+        $account = $this->getUserConfig($username);
+        $asReseller = $account['usertype'] === 'reseller';
+
+        if ($asReseller) {
+            $command = '/CMD_API_MODIFY_RESELLER';
+        } else {
+            $command = '/CMD_API_MODIFY_USER';
+        }
+
+        $query = array(
+            'action' => 'package',
+            'user' => $username,
+            'package' => $package_name,
+        );
+
+        $this->makeRequest($command, $query, null, 'POST');
+    }
+
+    public function getAccountUsage(string $username)
+    {
+        $command = '/CMD_API_SHOW_USER_USAGE';
+        $query = array(
+            'user' => $username,
+        );
+
+        $usage = $this->makeRequest($command, $query);
+        $config = $this->getUserConfig($username);
+
+        $disk = UnitsConsumed::create()
+            ->setUsed((float)$usage['quota'] ?? null)
+            ->setLimit($config['quota'] === 'unlimited' ? null : $config['quota']);
+
+        $bandwidth = UnitsConsumed::create()
+            ->setUsed((float)$usage['bandwidth'] ?? null)
+            ->setLimit($config['bandwidth'] === 'unlimited' ? null : $config['bandwidth']);
+
+        $inodes = UnitsConsumed::create()
+            ->setUsed((float)$usage['inode'] ?? null)
+            ->setLimit($config['inode'] === 'unlimited' ? null : $config['inode']);
+
+        return UsageData::create()
+            ->setDiskMb($disk)
+            ->setBandwidthMb($bandwidth)
+            ->setInodes($inodes);
+    }
+
+    public function getLoginUrl(string $username, string $ip): string
+    {
+        $this->getUserConfig($username);
+
+        $command = '/CMD_API_LOGIN_KEYS';
+        $query = array(
+            'action' => 'create',
+            'type' => 'one_time_url',
+            'login_keys_notify_on_creation' => 0,
+            'clear_key' => 'yes',
+            'expiry' => '30m',
+            'ips' => $ip,
+        );
+
+        $credentials = array(
+            $this->configuration->username . '|' . $username,
+            $this->configuration->password
+        );
+
+        $response = $this->makeRequest($command, $query, null, 'POST', $credentials);
+
+        return $response['result'];
+    }
+}

--- a/src/DirectAdmin/Data/Configuration.php
+++ b/src/DirectAdmin/Data/Configuration.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\DirectAdmin\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * DirectAdmin API credentials.
+ * @property-read string $hostname DirectAdmin server hostname
+ * @property-read string $username DirectAdmin username
+ * @property-read string $password DirectAdmin password
+ * @property-read bool|null $debug Whether or not to enable debug logging
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'hostname' => ['required', 'domain_name'],
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+            'debug' => ['boolean'],
+        ]);
+    }
+}

--- a/src/DirectAdmin/Provider.php
+++ b/src/DirectAdmin/Provider.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\DirectAdmin;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ServerException;
+use Throwable;
+use Carbon\Carbon;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionProviders\SharedHosting\Category;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountInfo;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsage;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsername;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePasswordParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\EmptyResult;
+use Upmind\ProvisionProviders\SharedHosting\Data\GetLoginUrlParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\GrantResellerParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\LoginUrl;
+use Upmind\ProvisionProviders\SharedHosting\Data\ResellerPrivileges;
+use Upmind\ProvisionProviders\SharedHosting\Data\SuspendParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\UsageData;
+use Upmind\ProvisionProviders\SharedHosting\DirectAdmin\Data\Configuration;
+
+class Provider extends Category implements ProviderInterface
+{
+    /**
+     * @var Configuration
+     */
+    protected Configuration $configuration;
+
+    /**
+     * @var Api
+     */
+    protected $api;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('DirectAdmin')
+            ->setDescription('Create and manage DirectAdmin accounts and resellers using the DirectAdmin API')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/direct-admin-logo@2x.png');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(CreateParams $params): AccountInfo
+    {
+        $asReseller = boolval($params->as_reseller ?? false);
+
+        if (!$asReseller) {
+            if (!$params->domain) {
+                throw $this->errorResult('Domain name is required');
+            }
+        }
+
+        if (!$params->custom_ip) {
+            throw $this->errorResult('Domain IP is required');
+        }
+
+        $username = $params->username ?? $this->generateUsername($params->domain);
+
+        try {
+            $this->api()->createAccount(
+                $params,
+                $username,
+                $asReseller,
+            );
+
+            if ($asReseller) {
+                return $this->_getInfo($username, 'Reseller account created');
+            } else {
+                return $this->_getInfo($username, 'Account created');
+            }
+
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    protected function generateUsername(string $base): string
+    {
+        return substr(
+            preg_replace('/^[^a-z]+/', '', preg_replace('/[^a-z0-9]/', '', strtolower($base))),
+            0,
+            $this->getMaxUsernameLength()
+        );
+    }
+
+    protected function getMaxUsernameLength(): int
+    {
+        return 16;
+    }
+
+    protected function _getInfo(string $username, string $message): AccountInfo
+    {
+        $info = $this->api()->getAccountData($username);
+
+        return AccountInfo::create($info)->setMessage($message);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getInfo(AccountUsername $params): AccountInfo
+    {
+        try {
+            return $this->_getInfo($params->username,
+                'Account info retrieved',
+            );
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function getUsage(AccountUsername $params): AccountUsage
+    {
+        try {
+            $usage = $this->api()->getAccountUsage($params->username);
+
+            return AccountUsage::create()
+                ->setUsageData($usage);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLoginUrl(GetLoginUrlParams $params): LoginUrl
+    {
+        try {
+            $loginUrl = $this->api()->getLoginUrl($params->username, $params->user_ip);
+
+            return LoginUrl::create()
+                ->setLoginUrl($loginUrl)
+                ->setExpires(Carbon::now()->addMinutes(30))
+                ->setForIp($params->user_ip);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function changePassword(ChangePasswordParams $params): EmptyResult
+    {
+        try {
+            $this->api()->updatePassword($params->username, $params->password);
+
+            return $this->emptyResult('Password changed');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function changePackage(ChangePackageParams $params): AccountInfo
+    {
+        try {
+            $this->api()->updatePackage($params->username, $params->package_name);
+
+            return $this->_getInfo(
+                $params->username,
+                'Package changed');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function suspend(SuspendParams $params): AccountInfo
+    {
+        try {
+            $this->api()->suspendAccount($params->username);
+
+            return $this->_getInfo($params->username, 'Account suspended');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unSuspend(AccountUsername $params): AccountInfo
+    {
+        try {
+            $this->api()->unsuspendAccount($params->username);
+
+            return $this->_getInfo($params->username, 'Account unsuspended');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function terminate(AccountUsername $params): EmptyResult
+    {
+        try {
+            $this->api()->deleteAccount($params->username);
+
+            return $this->emptyResult('Account deleted');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function grantReseller(GrantResellerParams $params): ResellerPrivileges
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function revokeReseller(AccountUsername $params): ResellerPrivileges
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws Throwable
+     */
+    protected function handleException(Throwable $e): void
+    {
+        if ($e instanceof ServerException) {
+            if ($e->hasResponse()) {
+                $response = $e->getResponse();
+                $reason = $response->getReasonPhrase();
+                $responseBody = $response->getBody()->__toString();
+                $responseData = json_decode($responseBody, true);
+                $errorMessage = $responseData['error'] . '. ' . $responseData['result'];
+
+                throw $this->errorResult(
+                    sprintf('Provider API error: %s', $errorMessage ?? $reason ?? null),
+                    [],
+                    ['response_data' => $responseData ?? null],
+                    $e
+                );
+            }
+        }
+
+        // let the provision system handle this one
+        throw $e;
+    }
+
+    protected function api(): Api
+    {
+        if ($this->api) {
+            return $this->api;
+        }
+
+        $credentials = base64_encode("{$this->configuration->username}:{$this->configuration->password}");
+
+        $client = new Client([
+            'base_uri' => sprintf('https://%s:2222', $this->configuration->hostname),
+            'headers' => [
+                'Authorization' => ['Basic ' . $credentials],
+            ],
+            'connect_timeout' => 10,
+            'timeout' => 60,
+            'http_errors' => true,
+            'allow_redirects' => false,
+            'handler' => $this->getGuzzleHandlerStack(!!$this->configuration->debug),
+        ]);
+
+        return $this->api = new Api($client, $this->configuration);
+    }
+}

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -12,6 +12,7 @@ use Upmind\ProvisionProviders\SharedHosting\WHMv1\Provider as WHMv1;
 use Upmind\ProvisionProviders\SharedHosting\PleskOnyxRPC\Provider as PleskOnyxRPC;
 use Upmind\ProvisionProviders\SharedHosting\TwentyI\Provider as TwentyI;
 use Upmind\ProvisionProviders\SharedHosting\Enhance\Provider as Enhance;
+use Upmind\ProvisionProviders\SharedHosting\DirectAdmin\Provider as DirectAdmin;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -26,5 +27,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('shared-hosting', 'plesk-onyx', PleskOnyxRPC::class);
         $this->bindProvider('shared-hosting', '20i', TwentyI::class);
         $this->bindProvider('shared-hosting', 'enhance', Enhance::class);
+        $this->bindProvider('shared-hosting', 'direct-admin', DirectAdmin::class);
     }
 }


### PR DESCRIPTION
The following operations are implemented for DirectAdmin:

create()
getInfo() 
getUsage()
getLoginUrl() 
changePassword()
changePackage()
suspend()
unSuspend()
terminate()

The following operations aren't supported by DirectAdmin:

grantReseller()
revokeReseller()