### PR TITLE
Add Centos WebPanel Implementation

### DIFF
--- a/src/CentosWeb/Api.php
+++ b/src/CentosWeb/Api.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\CentosWeb;
+
+use Illuminate\Support\Arr;
+use Upmind\ProvisionBase\Helper;
+use GuzzleHttp\Client;
+use RuntimeException;
+use Illuminate\Support\Str;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\UnitsConsumed;
+use Upmind\ProvisionProviders\SharedHosting\Data\UsageData;
+use Upmind\ProvisionProviders\SharedHosting\CentosWeb\Data\Configuration;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+
+class Api
+{
+    private Configuration $configuration;
+
+    protected Client $client;
+
+    public function __construct(Client $client, Configuration $configuration)
+    {
+        $this->client = $client;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function makeRequest(
+        string  $command,
+        ?array  $body = null,
+        ?string $method = 'POST',
+    ): ?array
+    {
+        $requestParams = [];
+
+        if ($body) {
+            $requestParams['form_params'] = $body;
+        }
+
+        $requestParams['form_params']['key'] = $this->configuration->api_key;
+
+        $response = $this->client->request($method, '/v1/' . $command, $requestParams);
+        $result = $response->getBody()->getContents();
+
+        $response->getBody()->close();
+
+        if ($result === "") {
+            return null;
+        }
+
+        return $this->parseResponseData($result);
+    }
+
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function parseResponseData(string $response): array
+    {
+        $parsedResult = json_decode($response, true);
+
+        if (!$parsedResult && Str::contains($response, '{"status":"OK"}')) {
+            return ['status' => 'OK'];
+        }
+
+        if ($error = $this->getResponseErrorMessage($parsedResult)) {
+            throw ProvisionFunctionError::create($error)
+                ->withData([
+                    'response' => $response,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+    private function getResponseErrorMessage(array $response): ?string
+    {
+        $status = $response['status'];
+        if ($status == 'Error' || (isset($response['msj']) && $response['msj'] === 'no records exist')) {
+            return $response['msj'] ?? $response['msl'] ?? 'Unknown error';
+        }
+
+        return null;
+    }
+
+    public function createAccount(CreateParams $params, string $username, bool $asReseller): void
+    {
+        $password = $params->password ?: Helper::generatePassword();
+
+        $body = [
+            'action' => 'add',
+            'domain' => $params->domain,
+            'user' => $username,
+            'pass' => $password,
+            'email' => $params->email,
+            'package' => $params->package_name,
+            'server_ips' => $params->custom_ip ?? $this->$this->configuration->ip
+        ];
+
+        if ($asReseller) {
+            $body['reseller'] = 1;
+        }
+
+        $this->makeRequest('account', $body);
+    }
+
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function getAccountData(string $username, bool $asReseller): array
+    {
+        $account = $this->getUserDetails($username, $asReseller);
+
+        return [
+            'username' => $username,
+            'domain' => $account['domain'] ?? null,
+            'reseller' => !($account['reseller'] == ""),
+            'server_hostname' => $this->configuration->hostname,
+            'package_name' => $account['package_name'],
+            'suspended' => $account['status'] === 'suspended',
+            'suspend_reason' => $account['suspended_reason'] ?? null,
+            'ip' => $account['ip_address'] ?? null,
+        ];
+    }
+
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getUserDetails(string $username, bool $asReseller): ?array
+    {
+        $body = [
+            'action' => 'list',
+        ];
+
+        if ($asReseller) {
+            $body['reseller'] = 1;
+        }
+
+        $response = $this->makeRequest('account', $body);
+
+        foreach ($response['msj'] as $account) {
+            if ($account['username'] == trim($username)) {
+                return $account;
+            }
+        }
+
+        throw ProvisionFunctionError::create("User does not exist")
+            ->withData([
+                'username' => $username,
+            ]);
+    }
+
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function getAccountUsage(string $username, bool $asReseller): UsageData
+    {
+        $account = $this->getUserDetails($username, $asReseller);
+
+        $disk = UnitsConsumed::create()
+            ->setUsed((int)$account['diskused'])
+            ->setLimit($account['disklimit'] != -1 ? (int)$account['disklimit'] : null);
+
+        $bandwidth = UnitsConsumed::create()
+            ->setUsed((int)$account['bandwidth'])
+            ->setLimit($account['bwlimit'] != -1 ? (int)$account['bwlimit'] : null);
+
+        return UsageData::create()
+            ->setDiskMb($disk)
+            ->setBandwidthMb($bandwidth);
+    }
+
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function suspendAccount(string $username): void
+    {
+        $body = [
+            'action' => 'susp',
+            'user' => $username
+        ];
+
+        $this->makeRequest('account', $body);
+    }
+
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function unsuspendAccount(string $username): void
+    {
+        $body = [
+            'action' => 'unsp',
+            'user' => $username
+        ];
+
+        $this->makeRequest('account', $body);
+    }
+
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function deleteAccount(string $username): void
+    {
+        $body = [
+            'action' => 'del',
+            'user' => $username
+        ];
+
+        $this->makeRequest('account', $body);
+    }
+
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function updatePassword(string $username, string $password): void
+    {
+        $body = [
+            'action' => 'udp',
+            'user' => $username,
+            'pass' => $password
+        ];
+
+        $this->makeRequest('changepass', $body);
+    }
+
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function updatePackage(string $username, int $package): void
+    {
+        $body = [
+            'action' => 'udp',
+            'user' => $username,
+            'package' => $package
+        ];
+
+        $this->makeRequest('changepack', $body);
+    }
+
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \RuntimeException
+     */
+    public function getLoginUrl(string $username, int $timer)
+    {
+        $body = [
+            'action' => 'list',
+            'user' => $username,
+            'timer' => $timer
+        ];
+
+        return $this->makeRequest('user_session', $body)['msj']['details'][0]['url'];
+    }
+}

--- a/src/CentosWeb/Data/Configuration.php
+++ b/src/CentosWeb/Data/Configuration.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\CentosWeb\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * CentosWeb API credentials.
+ * @property-read string $hostname server hostname
+ * @property-read string $api_key API key
+ * @property-read string|null $ip Account ip address
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'hostname' => ['required', 'domain_name'],
+            'api_key' => ['required', 'string'],
+            'ip' => ['nullable', 'ip'],
+        ]);
+    }
+}

--- a/src/CentosWeb/Provider.php
+++ b/src/CentosWeb/Provider.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SharedHosting\CentosWeb;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ServerException;
+use Carbon\Carbon;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\TransferException;
+use Throwable;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionProviders\SharedHosting\Category;
+use Upmind\ProvisionProviders\SharedHosting\Data\CreateParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountInfo;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsage;
+use Upmind\ProvisionProviders\SharedHosting\Data\AccountUsername;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\ChangePasswordParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\EmptyResult;
+use Upmind\ProvisionProviders\SharedHosting\Data\GetLoginUrlParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\GrantResellerParams;
+use Upmind\ProvisionProviders\SharedHosting\Data\LoginUrl;
+use Upmind\ProvisionProviders\SharedHosting\Data\ResellerPrivileges;
+use Upmind\ProvisionProviders\SharedHosting\Data\SuspendParams;
+use Upmind\ProvisionProviders\SharedHosting\CentosWeb\Data\Configuration;
+
+/**
+ * CentosWeb provision provider.
+ */
+class Provider extends Category implements ProviderInterface
+{
+    protected const MAX_USERNAME_LENGTH = 10;
+
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
+
+    /**
+     * @var Api|null
+     */
+    protected $api;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('CentosWeb')
+            ->setDescription('Create and manage CentosWeb accounts and resellers using the CentosWeb API')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/centosweb-logo.png');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function create(CreateParams $params): AccountInfo
+    {
+        $asReseller = boolval($params->as_reseller ?? false);
+
+        if (!$this->configuration->ip && !$params->custom_ip) {
+            $this->errorResult('Custom ip is required');
+        }
+
+        if (!$params->domain) {
+            $this->errorResult('Domain name is required');
+        }
+
+        $username = $params->username ?: $this->generateUsername($params->domain);
+
+        try {
+            $this->api()->createAccount(
+                $params,
+                $username,
+                $asReseller
+            );
+
+            return $this->_getInfo($username, $asReseller, 'Account created');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    protected function generateUsername(string $base): string
+    {
+        return substr(
+            preg_replace('/^[^a-z]+/', '', preg_replace('/[^a-z0-9]/', '', strtolower($base))),
+            0,
+            self::MAX_USERNAME_LENGTH
+        );
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    protected function _getInfo(string $username, bool $isReseller, string $message): AccountInfo
+    {
+        $info = $this->api()->getAccountData($username, $isReseller);
+
+        return AccountInfo::create($info)->setMessage($message);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getInfo(AccountUsername $params): AccountInfo
+    {
+        $asReseller = boolval($params->is_reseller ?? false);
+
+        try {
+            return $this->_getInfo(
+                $params->username,
+                $asReseller,
+                'Account info retrieved',
+            );
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getUsage(AccountUsername $params): AccountUsage
+    {
+        try {
+            $asReseller = boolval($params->is_reseller ?? false);
+
+            $usage = $this->api()->getAccountUsage($params->username, $asReseller);
+
+            return AccountUsage::create()
+                ->setUsageData($usage);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getLoginUrl(GetLoginUrlParams $params): LoginUrl
+    {
+        try {
+            $timer = 30;
+            $loginUrl = $this->api()->getLoginUrl($params->username, $timer);
+
+            return LoginUrl::create()
+                ->setLoginUrl($loginUrl)
+                ->setExpires(Carbon::now()->addMinutes($timer));
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function changePassword(ChangePasswordParams $params): EmptyResult
+    {
+        try {
+            $this->api()->updatePassword($params->username, $params->password);
+
+            return $this->emptyResult('Password changed');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function changePackage(ChangePackageParams $params): AccountInfo
+    {
+        try {
+            if (!is_numeric($params->package_name)) {
+                $this->errorResult('Package must be a numeric');
+            }
+
+            $this->api()->updatePackage($params->username, (int)$params->package_name);
+
+            return $this->_getInfo(
+                $params->username,
+                false,
+                'Package changed'
+            );
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function suspend(SuspendParams $params): AccountInfo
+    {
+        try {
+            $this->api()->suspendAccount($params->username);
+
+            return $this->_getInfo($params->username, false, 'Account suspended');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function unSuspend(AccountUsername $params): AccountInfo
+    {
+        try {
+            $this->api()->unsuspendAccount($params->username);
+
+            return $this->_getInfo($params->username, false, 'Account unsuspended');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function terminate(AccountUsername $params): EmptyResult
+    {
+        try {
+            $this->api()->deleteAccount($params->username);
+
+            return $this->emptyResult('Account deleted');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function grantReseller(GrantResellerParams $params): ResellerPrivileges
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function revokeReseller(AccountUsername $params): ResellerPrivileges
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @return no-return
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    protected function handleException(Throwable $e): void
+    {
+        if ($e instanceof ProvisionFunctionError) {
+            throw $e->withData(
+                array_merge($e->getData())
+            )->withDebug(
+                array_merge($e->getDebug())
+            );
+        }
+
+        // let the provision system handle this one
+        throw $e;
+    }
+
+    protected function api(): Api
+    {
+        if ($this->api) {
+            return $this->api;
+        }
+
+        $client = new Client([
+            'base_uri' => sprintf('https://%s:%s', $this->configuration->hostname, 2304),
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+            'connect_timeout' => 10,
+            'timeout' => 60,
+            'http_errors' => true,
+            'allow_redirects' => false,
+            'handler' => $this->getGuzzleHandlerStack(),
+        ]);
+
+        return $this->api = new Api($client, $this->configuration);
+    }
+}

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -15,6 +15,7 @@ use Upmind\ProvisionProviders\SharedHosting\TwentyI\Provider as TwentyI;
 use Upmind\ProvisionProviders\SharedHosting\Enhance\Provider as Enhance;
 use Upmind\ProvisionProviders\SharedHosting\InterWorx\Provider as InterWorx;
 use Upmind\ProvisionProviders\SharedHosting\DirectAdmin\Provider as DirectAdmin;
+use Upmind\ProvisionProviders\SharedHosting\CentosWeb\Provider as CentosWeb;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -32,5 +33,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('shared-hosting', 'inter-worx', InterWorx::class);
         $this->bindProvider('shared-hosting', 'solidcp', SolidCP::class);
         $this->bindProvider('shared-hosting', 'direct-admin', DirectAdmin::class);
+        $this->bindProvider('shared-hosting', 'centos-web', CentosWeb::class);
     }
 }


### PR DESCRIPTION
The following operations are implemented for CentosWeb Panel:

- create()
- getInfo()
- getUsage()
- getLoginUrl() 
- changePassword()
- changePackage()
- suspend()
- unSuspend()
- terminate()

The following operations aren't supported:

- grantReseller()
- revokeReseller()


The Centos API sometimes returns strange results. 
For example, on user removal:
```
{"status":"OK"}<pre><i aria-hidden='true' class='icomoon-icon-checkmark'></i> User *** deleted from server.<br><i aria-hidden='true' class='icomoon-icon-checkmark'></i> User and domains deleted from MySQL database.<br><i aria-hidden='true' class='icomoon-icon-checkmark'></i> Account Removal Script Completed! <br></pre>
```

We handled some of this, but perhaps there is more. 