### PR TITLE
86 - PanelApha - Create flow update

### DIFF
--- a/src/PanelAlpha/Api.php
+++ b/src/PanelAlpha/Api.php
@@ -91,21 +91,46 @@ class Api
     }
 
     /**
+     * Create a new domain and return the domain ID.
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function createDomain(string $serviceId, string $domain): string
+    {
+        $query = [
+            'domain' => $domain,
+        ];
+
+        $result = $this->makeRequest("services/{$serviceId}/domains", $query, 'POST');
+
+        if (empty($result) || !isset($result['id'])) {
+            throw ProvisionFunctionError::create('Failed to create domain for service')
+                ->withData([
+                    'service_id' => $serviceId,
+                    'domain' => $domain,
+                ]);
+        }
+
+        return (string) $result['id'];
+    }
+
+    /**
      * Create a new instance for the user and return the instance ID.
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
-    public function createInstance(string $userId, $serviceId, string $domain, string $name): string
+    public function createInstance(string $userId, $serviceId, string $domainId, string $name): string
     {
         $query = [
             'user_id' => $userId,
             'service_id' => $serviceId,
             'name' => $name,
-            'domain' => $domain,
+            'domain_id' => $domainId,
         ];
 
-        $result = $this->makeRequest('instances', $query, 'POST');
+        $result = $this->makeRequest('instances/install', $query, 'POST');
 
         if (empty($result) || !isset($result['id'])) {
             throw ProvisionFunctionError::create('Failed to create instance')

--- a/src/PanelAlpha/Api.php
+++ b/src/PanelAlpha/Api.php
@@ -78,6 +78,7 @@ class Api
 
         $query = [
             'plan_id' => $planId,
+            'status' => 'active', // Set initial status to active
         ];
 
         $result = $this->makeRequest("users/{$userId}/services", $query, 'POST');

--- a/src/PanelAlpha/Api.php
+++ b/src/PanelAlpha/Api.php
@@ -27,11 +27,7 @@ class Api
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
-    public function makeRequest(
-        string  $command,
-        ?array  $body = null,
-        ?string $method = 'GET'
-    ): ?array
+    public function makeRequest(string  $command, ?array  $body = null, ?string $method = 'GET'): ?array
     {
         $requestParams = [];
 
@@ -51,11 +47,11 @@ class Api
 
         $response = $this->client->request($method, "api/admin/{$command}", $requestParams);
 
-        $result = $response->getBody()->getContents();
+        $result = $response->getBody()->__toString();
 
         $response->getBody()->close();
 
-        if ($result === "") {
+        if ($result === '') {
             return null;
         }
 

--- a/src/PanelAlpha/Api.php
+++ b/src/PanelAlpha/Api.php
@@ -104,7 +104,7 @@ class Api
 
         $result = $this->makeRequest("services/{$serviceId}/domains", $query, 'POST');
 
-        if (empty($result) || !isset($result['id'])) {
+        if (!isset($result['id'])) {
             throw ProvisionFunctionError::create('Failed to create domain for service')
                 ->withData([
                     'service_id' => $serviceId,
@@ -138,7 +138,7 @@ class Api
                     'user_id' => $userId,
                     'service_id' => $serviceId,
                     'name' => $name,
-                    'domain' => $domain,
+                    'domain_id' => $domainId,
                 ]);
         }
 

--- a/src/PanelAlpha/Api.php
+++ b/src/PanelAlpha/Api.php
@@ -45,7 +45,7 @@ class Api
             }
         }
 
-        $response = $this->client->request($method, "api/admin/{$command}", $requestParams);
+        $response = $this->client->request($method, "api/{$command}", $requestParams);
 
         $result = $response->getBody()->__toString();
 
@@ -77,7 +77,7 @@ class Api
             'status' => 'active', // Set initial status to active
         ];
 
-        $result = $this->makeRequest("users/{$userId}/services", $query, 'POST');
+        $result = $this->makeRequest("admin/users/{$userId}/services", $query, 'POST');
 
         if (empty($result) || !isset($result['id'])) {
             throw ProvisionFunctionError::create('Failed to create service')
@@ -170,7 +170,7 @@ class Api
             $query['last_name'] = mb_substr($nameArray[1], 0, 255);
         }
 
-        $result = $this->makeRequest('users', $query, 'POST');
+        $result = $this->makeRequest('admin/users', $query, 'POST');
 
         if (empty($result) || !isset($result['id'])) {
             throw ProvisionFunctionError::create('Failed to create user')
@@ -239,7 +239,7 @@ class Api
      */
     public function getUserConfig(string $userId): array
     {
-        return $this->makeRequest("users/{$userId}");
+        return $this->makeRequest("admin/users/{$userId}");
     }
 
     /**
@@ -248,7 +248,7 @@ class Api
      */
     public function getUserServices(string $userId): array
     {
-        return $this->makeRequest("users/{$userId}/services");
+        return $this->makeRequest("admin/users/{$userId}/services");
     }
 
     /**
@@ -257,7 +257,7 @@ class Api
      */
     public function getInstances(string $userId): array
     {
-        return $this->makeRequest("users/{$userId}/all-instances");
+        return $this->makeRequest("admin/users/{$userId}/all-instances");
     }
 
     /**
@@ -285,7 +285,7 @@ class Api
                 ]);
         }
 
-        $this->makeRequest("users/$userId/services/$serviceId/suspend", null, 'PUT');
+        $this->makeRequest("admin/users/$userId/services/$serviceId/suspend", null, 'PUT');
     }
 
     /**
@@ -313,7 +313,7 @@ class Api
                 ]);
         }
 
-        $this->makeRequest("users/$userId/services/$serviceId/unsuspend", null, 'PUT');
+        $this->makeRequest("admin/users/$userId/services/$serviceId/unsuspend", null, 'PUT');
     }
 
     /**
@@ -324,7 +324,7 @@ class Api
      */
     public function findUserIdByEmail(string $email): string
     {
-        $result = $this->makeRequest('users/email', ['email' => $email]);
+        $result = $this->makeRequest('admin/users/email', ['email' => $email]);
 
         if (empty($result) || !isset($result['id'])) {
             throw ProvisionFunctionError::create('User does not exist')
@@ -361,12 +361,12 @@ class Api
 
             $serviceId = (string) $service['id'];
 
-            $this->makeRequest("services/{$serviceId}", null, 'DELETE');
+            $this->makeRequest("admin/services/{$serviceId}", null, 'DELETE');
         }
 
         // If no other services linked to the user, delete user.
         if (empty($this->getUserServices($userId))) {
-            $this->makeRequest("users/$userId", null, 'DELETE');
+            $this->makeRequest("admin/users/$userId", null, 'DELETE');
         }
     }
 
@@ -407,7 +407,7 @@ class Api
             'plan_id' => $planId,
         ];
 
-        $this->makeRequest("users/{$userId}/services/{$serviceId}/change-plan", $query, "PUT");
+        $this->makeRequest("admin/users/{$userId}/services/{$serviceId}/change-plan", $query, "PUT");
     }
 
     /**
@@ -456,7 +456,7 @@ class Api
             $userId = $this->findUserIdByEmail($userId);
         }
 
-        $sso = $this->makeRequest("users/{$userId}/sso-token", null, 'POST');
+        $sso = $this->makeRequest("admin/users/{$userId}/sso-token", null, 'POST');
 
         if (empty($sso) || !isset($sso['url'], $sso['token'])) {
             throw ProvisionFunctionError::create('Failed to get Login URL')
@@ -492,7 +492,7 @@ class Api
             'password' => $password,
         ];
 
-        $this->makeRequest("users/{$userId}", $query, "PUT");
+        $this->makeRequest("admin/users/{$userId}", $query, "PUT");
     }
 
     /**
@@ -501,7 +501,7 @@ class Api
      */
     private function getPlanId(string $plan): string
     {
-        $plans = $this->makeRequest('plans');
+        $plans = $this->makeRequest('admin/plans');
 
         foreach ($plans as $p) {
             if (!isset($p['id'], $p['name'])) {
@@ -586,7 +586,7 @@ class Api
      */
     private function deleteInstance(string $instanceId): void
     {
-        $this->makeRequest("instances/{$instanceId}", null, 'DELETE');
+        $this->makeRequest("admin/instances/{$instanceId}", null, 'DELETE');
     }
 
     /**

--- a/src/PanelAlpha/Api.php
+++ b/src/PanelAlpha/Api.php
@@ -409,16 +409,18 @@ class Api
         }
 
         $disk = UnitsConsumed::create()
-            ->setUsed((int)$usage['storage']["usage"] / 1024 / 1024)
+            ->setUsed(round((int) $usage['storage']["usage"] / (1024 * 1024), 2))
             ->setLimit(isset($usage['storage']['maximum']) && (int) $usage['storage']['maximum'] > 0
-                ? (int) ($usage['storage']['maximum'] / 1024 / 1024)
+                ? round((int) ($usage['storage']['maximum'] / (1024 * 1024)), 2)
                 : null
             );
 
         $bandwidth = UnitsConsumed::create()
-            ->setUsed((int)$usage['bandwidth']["usage"] / 1024 / 1024)
+            ->setUsed(round((int) $usage['bandwidth']["usage"] / (1024 * 1024), 2))
             ->setLimit(isset($usage['bandwidth']['maximum']) && (int) $usage['bandwidth']['maximum'] > 0
-                ? (int) ($usage['bandwidth']['maximum'] / 1024 / 1024) : null);
+                ? round((int) ($usage['bandwidth']['maximum'] / (1024 * 1024)), 2)
+                : null
+            );
 
         return UsageData::create()
             ->setDiskMb($disk)

--- a/src/PanelAlpha/Api.php
+++ b/src/PanelAlpha/Api.php
@@ -410,11 +410,15 @@ class Api
 
         $disk = UnitsConsumed::create()
             ->setUsed((int)$usage['storage']["usage"] / 1024 / 1024)
-            ->setLimit($usage['storage']['maximum'] != 0 ? (int)($usage['storage']['maximum'] / 1024 / 1024) : null);
+            ->setLimit(isset($usage['storage']['maximum']) && (int) $usage['storage']['maximum'] > 0
+                ? (int) ($usage['storage']['maximum'] / 1024 / 1024)
+                : null
+            );
 
         $bandwidth = UnitsConsumed::create()
             ->setUsed((int)$usage['bandwidth']["usage"] / 1024 / 1024)
-            ->setLimit($usage['bandwidth']['maximum'] != 0 ? (int)($usage['bandwidth']['maximum'] / 1024 / 1024) : null);
+            ->setLimit(isset($usage['bandwidth']['maximum']) && (int) $usage['bandwidth']['maximum'] > 0
+                ? (int) ($usage['bandwidth']['maximum'] / 1024 / 1024) : null);
 
         return UsageData::create()
             ->setDiskMb($disk)

--- a/src/PanelAlpha/Provider.php
+++ b/src/PanelAlpha/Provider.php
@@ -71,7 +71,8 @@ class Provider extends Category implements ProviderInterface
 
             // Create instance if domain is provided.
             if ($params->domain) {
-                $this->api()->createInstance($userId, $serviceId, $params->domain, $name);
+                $domainId = $this->api()->createDomain($serviceId, $params->domain);
+                $this->api()->createInstance($userId, $serviceId, $domainId, $name);
 
                 $message = 'Account created with hosting instance for domain: ' . $params->domain;
             }

--- a/src/PanelAlpha/Provider.php
+++ b/src/PanelAlpha/Provider.php
@@ -83,17 +83,6 @@ class Provider extends Category implements ProviderInterface
     }
 
     /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     */
-    protected function _getInfo(string $userId, ?string $serviceId, ?string $domain, string $message): AccountInfo
-    {
-        $info = $this->api()->getAccountData($userId, $serviceId, $domain);
-
-        return AccountInfo::create($info)->setMessage($message);
-    }
-
-    /**
      * @inheritDoc
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
@@ -348,6 +337,17 @@ class Provider extends Category implements ProviderInterface
     public function revokeReseller(AccountUsername $params): ResellerPrivileges
     {
         $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    protected function _getInfo(string $userId, ?string $serviceId, ?string $domain, string $message): AccountInfo
+    {
+        $info = $this->api()->getAccountData($userId, $serviceId, $domain);
+
+        return AccountInfo::create($info)->setMessage($message);
     }
 
     /**

--- a/src/PanelAlpha/Provider.php
+++ b/src/PanelAlpha/Provider.php
@@ -47,7 +47,7 @@ class Provider extends Category implements ProviderInterface
         return AboutData::create()
             ->setName('PanelAlpha')
             ->setDescription('Create and manage PanelAlpha accounts and resellers using the PanelAlpha API')
-            ->setLogoUrl('https://api.upmind.io/images/logos/provision/panel-alpha-logo.png');
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/panel-alpha-logo.svg');
     }
 
     /**

--- a/src/PanelAlpha/Provider.php
+++ b/src/PanelAlpha/Provider.php
@@ -71,8 +71,7 @@ class Provider extends Category implements ProviderInterface
 
             // Create instance if domain is provided.
             if ($params->domain) {
-                $domainId = $this->api()->createDomain($serviceId, $params->domain);
-                $this->api()->createInstance($userId, $serviceId, $domainId, $name);
+                $this->api()->createInstance($userId, $serviceId, $params->domain, $name);
 
                 $message = 'Account created with hosting instance for domain: ' . $params->domain;
             }
@@ -417,7 +416,7 @@ class Provider extends Category implements ProviderInterface
     {
         if ($params->customer_id !== null) {
             try {
-                $user = $this->api()->makeRequest('users/' . $params->customer_id);
+                $user = $this->api()->getUserConfig($params->customer_id);
 
                 if (0 === preg_match('/\_deleted\_\d+$/', $user['email'])) {
                     return (string) $params->customer_id;


### PR DESCRIPTION
Closes #86 

- Update create flow to pass `status` as `active` when creating service
- Update get Usage data to identify unlimited when returned result are negative numbers
- Fix PanelAlpha asset logo URL
- Use `__toString()` when getting response content so it fully rewinds the stream