### PR TITLE
V6.6 - handle zero resource limits in usage calculation

### DIFF
--- a/src/Data/UnitsConsumed.php
+++ b/src/Data/UnitsConsumed.php
@@ -63,7 +63,7 @@ class UnitsConsumed extends DataSet
         }
 
         if ((float) $this->get('limit') === 0.0) {
-            $this->setUsedPc('100%');
+            $this->setUsedPc('100%'); // Forced to 100% for resource limits of 0
             return $this;
         }
 

--- a/src/Data/UnitsConsumed.php
+++ b/src/Data/UnitsConsumed.php
@@ -62,6 +62,11 @@ class UnitsConsumed extends DataSet
             return $this;
         }
 
+        if ((float) $this->get('limit') === 0.0) {
+            $this->setUsedPc('100%');
+            return $this;
+        }
+
         $this->setUsedPc(
             round($this->get('used') / $this->get('limit') * 100, 1) . '%'
         );


### PR DESCRIPTION
Follow up MR for v6.6 from #97 

Sets usage to 100% when a resource limit is zero to prevent division-by-zero errors for disabled hosting plan resources.